### PR TITLE
improve catch child process errors

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -36,7 +36,7 @@ export const resolver = (resolveFrom: NodeJS.Process | ChildProcess = process) =
           payload = await Promise.resolve(channels[msg.channel](...msg.payload))
         } catch(err) {
           status = ResponseType.FAILED
-          payload = `${errorPrefix}${err.stack}`
+          payload = `${errorPrefix}${err}`
         }
       } else {
         status = ResponseType.FAILED


### PR DESCRIPTION
Improve child process errors catching.

Not all child process errors are standard `Error` anyway.